### PR TITLE
Excluded TextTemplatingFilePreprocessor files (not supported by TextTransform.exe).

### DIFF
--- a/nuget/build/Clarius.TransformOnBuild.targets
+++ b/nuget/build/Clarius.TransformOnBuild.targets
@@ -40,7 +40,7 @@
 
         <ItemGroup>
             <_TextTransform Include="@(None)"
-                            Condition="'%(None.Generator)' == 'TextTemplatingFilePreprocessor' Or '%(None.Generator)' == 'TextTemplatingFileGenerator'" />
+                            Condition="'%(None.Generator)' == 'TextTemplatingFileGenerator'" />
         </ItemGroup>
 
         <!-- Perform task batching for each file -->


### PR DESCRIPTION
Closes issue #2.
