### PR TITLE
Add support for passing parameters to TextTransform.exe command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,11 @@ If you would like to pass parameters to TextTransform.exe, define a group of Tex
 
 
 The Include attribute specifies the parameter name, and the Value metadata element specifies the parameter value.
+
+To access the parameter values from your text template, set `hostspecific` in the `template` directive and invoke `this.Host.ResolveParameterValue(...)`. For example:
+
+	<#@ template language="C#" hostspecific="true" #>
+	<#
+	    var foo = this.Host.ResolveParameterValue("", "", "Foo");
+	    var config = this.Host.ResolveParameterValue("", "", "Config");
+	#>

--- a/README.md
+++ b/README.md
@@ -21,3 +21,17 @@ If a full Visual Studio installation is not available on the build server, you c
 
 
 With that in place, the transformation will be performed using that file instead, if found.
+
+If you would like to pass parameters to TextTransform.exe, define a group of TextTransformParameter items as follows:
+
+	<ItemGroup>
+		<TextTransformParameter Include="Foo">
+			<Value>bar</Value>
+		</TextTransformParameter>
+		<TextTransformParameter Include="Config">
+			<Value>$(Configuration)</Value>
+		</TextTransformParameter>
+	</ItemGroup>
+
+
+The Include attribute specifies the parameter name, and the Value metadata element specifies the parameter value.

--- a/nuget/build/Clarius.TransformOnBuild.targets
+++ b/nuget/build/Clarius.TransformOnBuild.targets
@@ -41,8 +41,13 @@
                             Condition="'%(None.Generator)' == 'TextTemplatingFileGenerator'" />
         </ItemGroup>
 
+        <PropertyGroup>
+            <!-- TextTransformParameters is an external item list used to create parameter name/value pairs for the command line. -->
+            <_TransformExeParameters>@(TextTransformParameter->'-a "!!%(Identity)!%(Value)"', ' ')</_TransformExeParameters>
+        </PropertyGroup>
+
         <!-- Perform task batching for each file -->
-        <Exec Command="&quot;$(_TransformExe)&quot; &quot;%(_TextTransform.FullPath)&quot;"
+        <Exec Command="&quot;$(_TransformExe)&quot; $(_TransformExeParameters) &quot;%(_TextTransform.FullPath)&quot;"
               Condition="'%(_TextTransform.Identity)' != ''"/>
         
     </Target>

--- a/nuget/build/Clarius.TransformOnBuild.targets
+++ b/nuget/build/Clarius.TransformOnBuild.targets
@@ -42,7 +42,7 @@
         </ItemGroup>
 
         <PropertyGroup>
-            <!-- TextTransformParameters is an external item list used to create parameter name/value pairs for the command line. -->
+            <!-- TextTransformParameter is an external item list used to create parameter name/value pairs for the command line. -->
             <_TransformExeParameters>@(TextTransformParameter->'-a "!!%(Identity)!%(Value)"', ' ')</_TransformExeParameters>
         </PropertyGroup>
 


### PR DESCRIPTION
This PR enhances the package by adding the ability to pass arbitrary parameters  to the `TextTransform.exe` command line. (See the docs for the -a argument to `TextTransform.exe` at http://msdn.microsoft.com/en-us/library/bb126245.aspx) Parameters are gathered from items of type `TextTransformParameter`, where the item Identity metadata specifies the parameter name and special Value metadata specifies the parameter value. This approach was inspired by the `T4ParameterValues` item documented at http://msdn.microsoft.com/en-us/library/ee847423.aspx.
