### PR TITLE
Update tool search logic to work in VS2017

### DIFF
--- a/Clarius.TransformOnBuild.MSBuild.Task/Clarius.TransformOnBuild.MSBuild.Task/TransformOnBuildTask.cs
+++ b/Clarius.TransformOnBuild.MSBuild.Task/Clarius.TransformOnBuild.MSBuild.Task/TransformOnBuildTask.cs
@@ -15,6 +15,7 @@ namespace Clarius.TransformOnBuild.MSBuild.Task
     {
         private ProjectInstance _projectInstance;
         private Dictionary<string, string> _properties;
+        private string _programFiles;
         private string _commonProgramFiles;
         private string _textTransformPath;
         private string _transformExe;
@@ -135,6 +136,10 @@ namespace Clarius.TransformOnBuild.MSBuild.Task
             if (string.IsNullOrEmpty(_commonProgramFiles))
                 _commonProgramFiles = GetPropertyValue("CommonProgramFiles");
 
+            _programFiles = Environment.GetEnvironmentVariable("ProgramFiles(x86)");
+            if (string.IsNullOrEmpty(_programFiles))
+                _programFiles = GetPropertyValue("ProgramFiles");
+
             _textTransformPath = GetPropertyValue("TextTransformPath");
             if (string.IsNullOrEmpty(_textTransformPath))
                 _textTransformPath = string.Format(@"{0}\Microsoft Shared\TextTemplating\{1}\TextTransform.exe", _commonProgramFiles, GetPropertyValue("VisualStudioVersion"));
@@ -154,6 +159,18 @@ namespace Clarius.TransformOnBuild.MSBuild.Task
                 _transformExe = string.Format(@"{0}\Microsoft Shared\TextTemplating\13.0\TextTransform.exe", _commonProgramFiles);
             if (!File.Exists(_transformExe))
                 _transformExe = string.Format(@"{0}\Microsoft Shared\TextTemplating\14.0\TextTransform.exe", _commonProgramFiles);
+            
+            // VS2017 changed the location of the TextTransform.exe tool
+            // See https://docs.microsoft.com/en-us/visualstudio/modeling/generating-files-with-the-texttransform-utility
+            if (!File.Exists(_transformExe))
+                _transformExe = string.Format(@"{0}\Microsoft Visual Studio\2017\Professional\Common7\IDE\TextTransform.exe", _programFiles);
+            if (!File.Exists(_transformExe))
+                _transformExe = string.Format(@"{0}\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\TextTransform.exe", _programFiles);
+            // Preview versions live in their own subfolder...
+            if (!File.Exists(_transformExe))
+                _transformExe = string.Format(@"{0}\Microsoft Visual Studio\Preview\Professional\Common7\IDE\TextTransform.exe", _programFiles);
+            if (!File.Exists(_transformExe))
+                _transformExe = string.Format(@"{0}\Microsoft Visual Studio\Preview\Enterprise\Common7\IDE\TextTransform.exe", _programFiles);
         }
 
         /// <summary>


### PR DESCRIPTION
As of VS2017, the location of the TextTransform.exe file has changed from the Common Program Files location to <ProgramFiles(X86)>\Microsoft Visual Studio\2017\<Edition>\Common7\IDE as per https://docs.microsoft.com/en-us/visualstudio/modeling/generating-files-with-the-texttransform-utility

As well, when VS 2017 Preview is installed, it is located in <ProgramFiles(X86)>\Microsoft Visual Studio\Preview\<Edition>\Common7\IDE.

Resolves #42 